### PR TITLE
Added the monitoring of the template folder for packages

### DIFF
--- a/generators/packagePacker/packagePacker.ts
+++ b/generators/packagePacker/packagePacker.ts
@@ -161,8 +161,9 @@ export class PackagePacker {
 
             switch (configuration.type) {
                 case ComponentType.Component: container.get<DriverTemplatesProcessor>(TYPES.Processors.DriverTemplates).process(configuration.templates, destination);
+                case ComponentType.TasksPackage:
                 case ComponentType.TasksLibrary: container.get<LibraryTemplatesProcessor>(TYPES.Processors.LibraryTemplates).process(configuration.templates, destination);
-            }            
+            }
         }
 
         // process Post actions

--- a/generators/packagePacker/processors/libraryTemplates.ts
+++ b/generators/packagePacker/processors/libraryTemplates.ts
@@ -45,7 +45,7 @@ export class LibraryTemplatesProcessor {
             templateRules = this._paths.transform(templateRules);
 
             if (!io.existsSync(templateRules)) {
-                this._logger.Warn(` [Templates] Directory '${templateRules}' doesn't exist`);
+                throw new Error(` [Templates] Directory '${templateRules}' doesn't exist`);
             } else {
                 const files = io.readdirSync(templateRules);
                 for (let file of files) {
@@ -53,7 +53,7 @@ export class LibraryTemplatesProcessor {
                         this.merge(path.join(templateRules, file));
                     }
                 }
-            
+
             }
         } else {
             // Process each template entry


### PR DESCRIPTION
Added the monitoring of the template folder for packages that have both ATL and old type tasks.
Changed a warning to an error when the folder of tha ATL templates don't exist.